### PR TITLE
Add charging point info in outputs

### DIFF
--- a/simbev/helpers/helpers.py
+++ b/simbev/helpers/helpers.py
@@ -143,9 +143,6 @@ def compile_output(result_dir: Path, start, end, region_mode, timestep=15):
     power_columns = ["sum CS power", "sum UC work", "sum UC business", "sum UC school",
                      "sum UC shopping", "sum UC private/ridesharing", "sum UC leisure",
                      "sum UC home", "sum UC hub"]
-    # columns:
-    # sum CS power;sum UC work;sum UC business;sum UC school;sum UC shopping;
-    # sum UC private/ridesharing;sum UC leisure;sum UC home;sum UC hub
 
     # run through all csv result files of this run that include "standing_times" in the title
     sub_dirs = [f for f in result_dir.iterdir() if f.is_dir()]
@@ -200,6 +197,88 @@ def compile_output(result_dir: Path, start, end, region_mode, timestep=15):
     if region_mode == "multi":
         pd_result_sum = pd_result_sum.round(4)
         pd_result_sum.to_csv(Path(result_dir, "0_grid_timeseries_all_regions.csv"), sep=',', decimal='.')
+
+
+def compile_output_by_usecase(result_dir: Path, start, end, region_mode, timestep=15):
+    """
+
+    Parameters
+    ----------
+    result_dir : :obj:`Path`
+        Path to scenario results
+    start : :obj:`datetime`
+        starting time of simulation
+    end : :obj:`datetime`
+        ending time of simulation
+    region_mode : :obj:`string`
+        single or multi region simulation
+    timestep : :obj:`int`
+        time step of simulation in minutes
+
+    Returns
+    -------
+
+    """
+    # create Dataframe, take start and end date + timestep as parameter, build timeseries as index
+    dt_range = pd.date_range(start, end + dt.timedelta(days=1), freq=str(timestep)+'min')
+    pd_result = pd.DataFrame(0.0, index=range(len(dt_range)),
+                             columns=["time", "sum cs power", "sum hpc", "sum public", "sum home", "sum work"])
+    # fill rest with zeroes
+    pd_result["time"] = dt_range
+    pd_result_sum = pd_result.copy()
+    power_columns = ["sum cs power", "sum hpc", "sum public", "sum home", "sum work"]
+
+    # run through all csv result files of this run that include "standing_times" in the title
+    sub_dirs = [f for f in result_dir.iterdir() if f.is_dir()]
+    for dir_count, sub_dir in enumerate(sub_dirs):
+        files = list(sub_dir.rglob("*events.csv"))
+        print('Compiling usecase output for region %d/%d' % (dir_count+1, len(sub_dirs)), end='\n')
+        for file_count, file in enumerate(files):
+            progress_bar(file_count, len(files), sub_dir.name + " progress")
+            file_df = pd.read_csv(file, sep=',', decimal='.')
+            # file_df relevant columns: location,netto_charging_capacity,chargingdemand,charge_time,park_start,park_end
+            for i in file_df.index:
+                demand = file_df.loc[i, "chargingdemand_kWh"]
+                if demand > 0:
+                    # extract parameters for the charging event
+                    uc = file_df.loc[i, "use_case"]
+                    col = "sum " + uc
+                    park_time = file_df.loc[i, "park_time_timesteps"]
+                    park_start = file_df.loc[i, "park_start_timesteps"]
+                    cap_car = file_df.loc[i, "battery_charging_capacity_kW"]
+                    cap_grid = file_df.loc[i, "grid_charging_capacity_kW"]
+                    max_charge = cap_car * timestep / 60
+                    # average power in each time step
+                    power = []
+                    for k in range(park_time):
+                        # if possible charge with max power, greedy strat
+                        if demand >= max_charge:
+                            power.append(cap_grid)
+                            demand -= max_charge
+                        else:
+                            power.append(demand / timestep * 60 * cap_grid / cap_car)
+                            demand = 0
+                    # add charging series to result pandas
+                    for count, p in enumerate(power):
+                        if park_start + count < len(pd_result.index):
+                            pd_result.loc[park_start + count, col] += p
+                        else:
+                            # print("There is " + str(p) + " kW to charge in timestep " + str(park_start + count))
+                            break
+
+        pd_result["sum cs power"] = (pd_result["sum work"] + pd_result["sum public"] +
+                                     pd_result["sum hpc"] + pd_result["sum home"])
+
+        pd_result = pd_result.round(4)
+
+        pd_result.to_csv(Path(result_dir, sub_dir.name + "_grid_timeseries_uc.csv"), sep=',', decimal='.')
+        if region_mode == "multi":
+            pd_result_sum[power_columns] += pd_result[power_columns]
+        pd_result[power_columns] = 0.0
+
+    if region_mode == "multi":
+        pd_result_sum = pd_result_sum.round(4)
+        pd_result_sum.to_csv(Path(result_dir, "0_grid_timeseries_all_regions_uc.csv"), sep=',', decimal='.')
 
 
 # if __name__ == '__main__':

--- a/simbev/main_simbev.py
+++ b/simbev/main_simbev.py
@@ -202,10 +202,10 @@ def run_simbev(region_ctr, region_id, region_data, cfg_dict, charge_prob,
                 charging_car,
                 car_type_name,
                 icar,
-                stepsize,
-                len(tseries_purpose),
                 tech_data_car.battery_capacity,
                 rng,
+                cfg_dict["home_private"],
+                cfg_dict["work_private"],
                 eta_cp,
                 region_path,
                 tseries_purpose,
@@ -263,6 +263,9 @@ def init_simbev(args):
     charge_prob = {'slow': charge_prob_slow,
                    'fast': charge_prob_fast}
 
+    home_private = cfg.getfloat('charging_probabilities', 'private_charging_home')
+    work_private = cfg.getfloat('charging_probabilities', 'private_charging_work')
+
     # get timestep (in minutes)
     stepsize = cfg.getint('basic', 'stepsize')
 
@@ -290,6 +293,8 @@ def init_simbev(args):
                 'eta_cp': eta_cp,
                 'start_date': s_date,
                 'end_date': e_date,
+                'home_private': home_private,
+                'work_private': work_private,
                 }
 
     # create directory for standing times data

--- a/simbev/main_simbev.py
+++ b/simbev/main_simbev.py
@@ -263,8 +263,8 @@ def init_simbev(args):
     charge_prob = {'slow': charge_prob_slow,
                    'fast': charge_prob_fast}
 
-    home_private = cfg.getfloat('charging_probabilities', 'private_charging_home')
-    work_private = cfg.getfloat('charging_probabilities', 'private_charging_work')
+    home_private = cfg.getfloat('charging_probabilities', 'private_charging_home', fallback=1.0)
+    work_private = cfg.getfloat('charging_probabilities', 'private_charging_work', fallback=1.0)
 
     # get timestep (in minutes)
     stepsize = cfg.getint('basic', 'stepsize')

--- a/simbev/main_simbev.py
+++ b/simbev/main_simbev.py
@@ -8,12 +8,7 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 import multiprocessing as mp
-from helpers.helpers import (
-    single_to_multi_scenario,
-    export_metadata,
-    compile_output
-)
-
+import helpers.helpers as helper
 
 # regiotypes:
 # Ländliche Regionen
@@ -285,6 +280,7 @@ def init_simbev(args):
 
     # get output option
     grid_output = cfg.getboolean('basic', 'grid_timeseries', fallback=False)
+    uc_output = cfg.getboolean('basic', 'grid_timeseries_by_usecase', fallback=False)
 
     # combine config params in one dict
     cfg_dict = {'stepsize': stepsize,
@@ -320,7 +316,7 @@ def init_simbev(args):
             num_threads = 1
             print('Warning: Single region mode selected, therefore number of threads is set to 1.')
 
-        regions, tech_data = single_to_multi_scenario(
+        regions, tech_data = helper.single_to_multi_scenario(
             region_type=cfg.get('basic', 'regio_type'),
             rampup=dict(cfg['rampup_ev']),
             max_charging_capacity_slow=dict(cfg['tech_data_cc_slow']),
@@ -353,7 +349,7 @@ def init_simbev(args):
     start = dt.date(s_date[0], s_date[1], s_date[2])
     end = dt.date(e_date[0], e_date[1], e_date[2])
 
-    export_metadata(
+    helper.export_metadata(
         main_path,
         args.scenario,
         cfg,
@@ -364,7 +360,9 @@ def init_simbev(args):
     )
 
     if grid_output:
-        compile_output(main_path, start, end, region_mode, cfg_dict["stepsize"])
+        helper.compile_output(main_path, start, end, region_mode, cfg_dict["stepsize"])
+    if uc_output:
+        helper.compile_output_by_usecase(main_path, start, end, region_mode, cfg_dict["stepsize"])
 
 
 if __name__ == "__main__":

--- a/simbev/scenarios/default_RS7/simbev_config.cfg
+++ b/simbev/scenarios/default_RS7/simbev_config.cfg
@@ -23,6 +23,7 @@ start_date = 2021-09-17
 end_date = 2021-09-30
 soc_min = 0.2
 grid_timeseries = false
+grid_timeseries_by_usecase = false
 
 
 [rampup_ev]

--- a/simbev/scenarios/default_RS7/simbev_config.cfg
+++ b/simbev/scenarios/default_RS7/simbev_config.cfg
@@ -39,9 +39,12 @@ tech_data = tech_data.csv
 
 [charging_probabilities]
 # charging probabilities for all locations
+# share of private charging at home/work, 1 equals 100%
 
 slow = charging_point_probability.csv
 fast = fast_charging_probability.csv
+private_charging_home = 0.5
+private_charging_work = 0.7
 
 
 [sim_params]

--- a/simbev/scenarios/default_multi/simbev_config.cfg
+++ b/simbev/scenarios/default_multi/simbev_config.cfg
@@ -23,6 +23,7 @@ start_date = 2021-09-17
 end_date = 2021-09-30
 soc_min = 0.2
 grid_timeseries = false
+grid_timeseries_by_usecase = false
 
 
 [rampup_ev]

--- a/simbev/scenarios/default_multi/simbev_config.cfg
+++ b/simbev/scenarios/default_multi/simbev_config.cfg
@@ -39,9 +39,12 @@ tech_data = tech_data.csv
 
 [charging_probabilities]
 # charging probabilities for all locations
+# share of private charging at home/work, 1 equals 100%
 
 slow = charging_point_probability.csv
 fast = fast_charging_probability.csv
+private_charging_home = 0.5
+private_charging_work = 0.7
 
 
 [sim_params]

--- a/simbev/scenarios/default_single/simbev_config.cfg
+++ b/simbev/scenarios/default_single/simbev_config.cfg
@@ -25,6 +25,7 @@ start_date = 2021-09-17
 end_date = 2021-09-30
 soc_min = 0.2
 grid_timeseries = false
+grid_timeseries_by_usecase = false
 
 [rampup_ev]
 

--- a/simbev/scenarios/default_single/simbev_config.cfg
+++ b/simbev/scenarios/default_single/simbev_config.cfg
@@ -95,10 +95,12 @@ PHEV_luxury = 0.16
 
 # charging probabilities for all locations
 # ===========================
-#
+# share of private charging at home/work, 1 equals 100%
 
 slow = charging_point_probability.csv
 fast = fast_charging_probability.csv
+private_charging_home = 0.5
+private_charging_work = 0.7
 
 
 [sim_params]

--- a/simbev/simbevMiD.py
+++ b/simbev/simbevMiD.py
@@ -734,10 +734,10 @@ def charging_flexibility(
         charging_car,
         car_type,
         car_number,
-        stepsize,
-        day_count,
         bat_cap,
         rng,
+        home_private,
+        work_private,
         eta,
         path,
         tseries_purpose,
@@ -755,16 +755,19 @@ def charging_flexibility(
         Car type
     car_number : int
         Number of car in it's car type group
-    stepsize : int
-        Stepsize of timestamps
-    day_count : int
-        Number of simulated days
     bat_cap : int
         Battery Capacity of the car type
-    directory : str
-        Directory with sub-directories. Default: res.
-    sub_directory : str
-        Sub-directory with the standing times CSVs. Default: SR_Metro.
+    rng : :obj:`int`
+        seed for use of random
+    home_private
+    work_private
+    eta
+    path
+    tseries_purpose
+    days
+    batterycap : int
+        Battery Capacity of the car type
+    region_type
 
     """
 
@@ -870,12 +873,6 @@ def charging_flexibility(
     charging_car.rename(columns={"charge_start": "park_start"}, inplace=True)
     charging_car.rename(columns={"charge_end": "park_end"}, inplace=True)
 
-    # check SoC
-    # check_soc = charging_car['SoC_end'] < 0.19
-    # if check_soc.any():
-    #     print('SoC error')
-    #     breakpoint()
-
     # reorder columns
     charging_car = charging_car[
         [
@@ -912,7 +909,6 @@ def charging_flexibility(
                 charging_car['chargingdemand'].iloc[0] = 0
             else:
                 charging_car['chargingdemand'].iloc[0] = first_row['chargingdemand'] - cut_demand
-
 
     x = -672
     # index von park start end und drive start und end minus eine woche
@@ -1011,20 +1007,38 @@ def charging_flexibility(
 
     # rename columns
     charging_car = charging_car.rename(columns={
-        "location" : "location",
-        "nominal_charging_capacity_kW" : "nominal_charging_capacity_kW",
-        "grid_charging_capacity_kW" : "grid_charging_capacity_kW",
-        "battery_charging_capacity_kW" : "battery_charging_capacity_kW",
-        "SoC_start" : "soc_start",
-        "SoC_end" : "soc_end",
-        "chargingdemand" : "chargingdemand_kWh",
-        "charge_time" : "park_time_timesteps",
-        "park_start" : "park_start_timesteps",
-        "park_end" : "park_end_timesteps",
-        "drive_start" : "drive_start_timesteps",
-        "drive_end" : "drive_end_timesteps",
-        "consumption" : "consumption_kWh",
+        "location": "location",
+        "nominal_charging_capacity_kW": "nominal_charging_capacity_kW",
+        "grid_charging_capacity_kW": "grid_charging_capacity_kW",
+        "battery_charging_capacity_kW": "battery_charging_capacity_kW",
+        "SoC_start": "soc_start",
+        "SoC_end": "soc_end",
+        "chargingdemand": "chargingdemand_kWh",
+        "charge_time": "park_time_timesteps",
+        "park_start": "park_start_timesteps",
+        "park_end": "park_end_timesteps",
+        "drive_start": "drive_start_timesteps",
+        "drive_end": "drive_end_timesteps",
+        "consumption": "consumption_kWh",
     })
+
+    # add use case column
+    charging_car.insert(1, "use_case", "")
+    # determine if car has access to private charging at home/work
+    home_charge = home_private >= rng.random()
+    work_charge = work_private >= rng.random()
+    for i in charging_car.index:
+        loc = charging_car.loc[i, "location"]
+        if loc == "driving":
+            continue
+        elif loc == "7_charging_hub":
+            charging_car.loc[i, "use_case"] = "hpc"
+        elif loc == "0_work" and work_charge:
+            charging_car.loc[i, "use_case"] = "work"
+        elif loc == "6_home" and home_charge:
+            charging_car.loc[i, "use_case"] = "home"
+        else:
+            charging_car.loc[i, "use_case"] = "public"
 
     # round values in dataframe to decrease file size
     charging_car = charging_car.round(4)


### PR DESCRIPTION
This adds the column `use_case` to the vehicle output csv, as well as an option for a regional combined output csv by usecase. 
The former can be tested by running any scenario, the latter requires changing the config option `grid_timeseries_by_usecase` to `true`.

Availability of private work or home charging infrastructure is randomly (according to config options `private_charging_home` and
`private_charging_work`) determined once per car.