### PR TITLE
Fix results ending too early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Here is a template for new release sections
 ### Changed
 
 - Fix last event in event list when time range is exceeded #66
+- Fix first event in event list: set `park_start` to 0 when `park_start`>0 #66
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Here is a template for new release sections
 
 ### Changed
 
-- Fix last event in event list #66
+- Fix last event in event list when time range is exceeded #66
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@ Here is a template for new release sections
 ## [_._._] - 20XX-MM-DD
 
 ### Added
+
 -
+
 ### Changed
--
+
+- Fix last event in event list #66
+
 ### Removed
+
 -
 ```
 

--- a/simbev/simbevMiD.py
+++ b/simbev/simbevMiD.py
@@ -986,6 +986,13 @@ def charging_flexibility(
         # if charging_car.loc[row + 1, 'drive_end'] > bound:
         #     charging_car.loc[row + 1, 'drive_end'] = bound
         #     print('Error out of bound')
+
+    # set last event end to final time step
+    if charging_car["park_end"].iloc[-1]:
+        charging_car.loc[charging_car.index[-1], "park_end"] = bound
+    elif charging_car["drive_end"].iloc[-1]:
+        charging_car.loc[charging_car.index[-1], "drive_end"] = bound
+
     list_park_end = list(charging_car['park_end'])
     # last index
     last = list_park_end[-1]

--- a/simbev/simbevMiD.py
+++ b/simbev/simbevMiD.py
@@ -987,11 +987,20 @@ def charging_flexibility(
         #     charging_car.loc[row + 1, 'drive_end'] = bound
         #     print('Error out of bound')
 
+    # =============== QUICK FIX for #66 ===============
+    # remove last event if bound is exceeded
+    if charging_car["park_start"].iloc[-1] > bound:
+        charging_car = charging_car.iloc[:-1]
+    if charging_car["drive_start"].iloc[-1] > bound:
+        charging_car = charging_car.iloc[:-1]
+
     # set last event end to final time step
+    # CAUTION: The consumption might get flawed at this event
     if charging_car["park_end"].iloc[-1]:
         charging_car.loc[charging_car.index[-1], "park_end"] = bound
     elif charging_car["drive_end"].iloc[-1]:
         charging_car.loc[charging_car.index[-1], "drive_end"] = bound
+    # =================================================
 
     list_park_end = list(charging_car['park_end'])
     # last index

--- a/simbev/simbevMiD.py
+++ b/simbev/simbevMiD.py
@@ -1000,6 +1000,10 @@ def charging_flexibility(
         charging_car.loc[charging_car.index[-1], "park_end"] = bound
     elif charging_car["drive_end"].iloc[-1]:
         charging_car.loc[charging_car.index[-1], "drive_end"] = bound
+
+    # make first event start with 0
+    if charging_car["park_start"].iloc[0] > 0:
+        charging_car.loc[charging_car.index[0], "park_start"] = 0
     # =================================================
 
     list_park_end = list(charging_car['park_end'])


### PR DESCRIPTION
A more thorough look at outputs is happening in #41

For now. this PR fixes #66 by changing the last event end (park_end or drive_end) to the last possible timestep.