### PR TITLE
Replace static time values with time steps variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 simbev/results/*/
+simbev/scenarios/
 *.pyc
 .pytest_cache
 .vscode
@@ -10,3 +11,4 @@ _build
 .tox
 .coverage
 .idea
+venv/

--- a/simbev/car.py
+++ b/simbev/car.py
@@ -214,13 +214,13 @@ class Car:
             t_load[0] = t_diff
 
             p_soc = p_soc[k - 1:]
-            chargepower_timestep = sum(e_load)*60/15
+            chargepower_timestep = sum(e_load) * 60 / step_size
 
             use_case = self._get_usecase(power)
             self.region.update_grid_timeseries(use_case, chargepower_timestep, power, trip.park_start + i,
                                                trip.park_start + i + 1)
 
-        chargepower_avg = sum(charged_energy_list) / len(charged_energy_list)*60/15
+        chargepower_avg = sum(charged_energy_list) / len(charged_energy_list) * 60 / step_size
 
         return time_steps, chargepower_avg, power, soc_end
 


### PR DESCRIPTION
At a few points in the code a static 15 was used instead of the step size parameter. This results in faulty grid timeseries when using step sizes that are not 15 