### PR TITLE
Feature/random seed driving profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is inspired from [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and the versioning aim to respect [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased] - 2024-05-17
+
+### Added
+
+- driving_profile_seed parameter in the config file to set the seed for the driving profile generation step #139
+
+### Changed
+
+- Results are the same for the same seed specified in the config file #139
+
 ## [1.0.0] - 2022-07-15
 
 ### Added

--- a/scenarios/default/configs/default.cfg
+++ b/scenarios/default/configs/default.cfg
@@ -86,4 +86,5 @@ energy_min = energy_min.csv
 scaling = 1
 num_threads = 4
 seed = 3
+driving_profile_seed = 10
 private_only_run = false

--- a/scenarios/default_RS7/configs/default.cfg
+++ b/scenarios/default_RS7/configs/default.cfg
@@ -88,4 +88,5 @@ energy_min = energy_min.csv
 scaling = 1
 num_threads = 4
 seed = 3
+driving_profile_seed = 10
 private_only_run = false

--- a/simbev/mid_timeseries.py
+++ b/simbev/mid_timeseries.py
@@ -223,7 +223,7 @@ def get_empty_timeseries(start_date, end_date, step_size):
     return pd.DataFrame([0] * len(date_range), index=date_range)
 
 
-def get_profile_time_series(start_date, end_date, step_size, df):
+def get_profile_time_series(start_date, end_date, step_size, df, seed):
     """
     Returns a time series starting from the start date up until the end date filled with
     week data chosen at random from the input DataFrame for each week.
@@ -258,6 +258,7 @@ def get_profile_time_series(start_date, end_date, step_size, df):
     week_start = start_date
     time_step = 0
     steps_per_day = 1440 / step_size
+    np.random.seed(seed)
     while week_start <= end_date:
         # Select a random ID from the input DataFrame
 

--- a/simbev/mid_timeseries.py
+++ b/simbev/mid_timeseries.py
@@ -238,6 +238,8 @@ def get_profile_time_series(start_date, end_date, step_size, df, seed):
         Step size of the simulation in minutes.
     df : pd.DataFrame
         The input DataFrame containing week data, where each entry with the same ID belongs to the same week.
+    seed : int
+        Seed for the random number generator.
 
     Returns
     -------

--- a/simbev/simbev_class.py
+++ b/simbev/simbev_class.py
@@ -525,6 +525,8 @@ class SimBEV:
             public_count = 0
             for car_type_name, car_count in region.car_dict.items():
                 for car_number in range(car_count):
+                    # Update driving profile seed
+                    self.driving_profile_seed += 1
                     # Create new car
                     if "max_charging_capacity_slow" in self.tech_data.columns:
                         car_type = self.car_types[car_type_name]
@@ -608,6 +610,7 @@ class SimBEV:
                             self.input_data[region.region_type.rs3_type][
                                 car_type_name.split("_")[-1]
                             ],
+                            self.driving_profile_seed,
                         )
 
                     if self.num_threads == 1:

--- a/simbev/simbev_class.py
+++ b/simbev/simbev_class.py
@@ -277,6 +277,7 @@ class SimBEV:
                     file_path_parts[-1]
                 ] = pd.read_parquet(file_path)
         self.scaling = config_dict["scaling"]
+        self.driving_profile_seed = config_dict["driving_profile_seed"]
         # additional parameters
         self.regions: List[Region] = []
         self.created_region_types = {}

--- a/simbev/simbev_class.py
+++ b/simbev/simbev_class.py
@@ -1093,7 +1093,9 @@ class SimBEV:
                 "basic", "consumption_factor_highway", fallback=1.0
             ),
             "rng_seed": cfg["sim_params"].getint("seed", None),
-            "driving_profile_seed": cfg["sim_params"].getint("driving_profile_seed", None),
+            "driving_profile_seed": cfg["sim_params"].getint(
+                "driving_profile_seed", None
+            ),
             "eta_cp": cfg.getfloat("basic", "eta_cp", fallback=1),
             "start_date": start_date,
             "end_date": end_date,

--- a/simbev/simbev_class.py
+++ b/simbev/simbev_class.py
@@ -1089,6 +1089,7 @@ class SimBEV:
                 "basic", "consumption_factor_highway", fallback=1.0
             ),
             "rng_seed": cfg["sim_params"].getint("seed", None),
+            "driving_profile_seed": cfg["sim_params"].getint("driving_profile_seed", None),
             "eta_cp": cfg.getfloat("basic", "eta_cp", fallback=1),
             "start_date": start_date,
             "end_date": end_date,


### PR DESCRIPTION
Fixes #138

**Changes proposed in this pull request**:
- A random seed is added to the get_profile_time_series() function in order to obtain always the same results.

The following steps were realized (required):
- [x] Correct formatting with `black src`
- [x] Add the description of your changes to the CHANGELOG.md in subsection with release name `[Unreleased]` and state the PR number with `#`

Also the following steps were realized if applicable:
- [x] Write docstrings to your code
- [ ] Write test(s) for new patch of code
